### PR TITLE
try to render notes

### DIFF
--- a/app/screens/AddContact.js
+++ b/app/screens/AddContact.js
@@ -19,6 +19,15 @@ export default class AddContact extends Component {
     };
   }
 
+  componentWillReceiveProps(newProps) {
+    this.setState({
+      firstName: newProps.firstName,
+      lastName: newProps.lastName,
+      birthdayDate: newProps.birthdayDate,
+      avatar: newProps.avatar || null
+    });
+  }
+
   setAvatar(avatar) {
     this.setState({
       avatar: avatar
@@ -32,6 +41,7 @@ export default class AddContact extends Component {
 
   resetContactState() {
     Actions.contactList();
+    Actions.pop();
     this.setState({
       firstName: '',
       lastName: '',
@@ -39,11 +49,6 @@ export default class AddContact extends Component {
       avatar: null
     });
   }
-
-  // updateContact(id) {
-  //   const editRef = firebase.database().ref(`contacts/${id}`);
-  //   editRef.push(this.state);
-  // }
 
   render() {
     return (

--- a/app/screens/AddContact.js
+++ b/app/screens/AddContact.js
@@ -40,14 +40,10 @@ export default class AddContact extends Component {
     });
   }
 
-  componentWillUnmount() {
-    this.setState({
-      firstName: '',
-      lastName: '',
-      birthdayDate: new Date(),
-      avatar: null
-    });
-  }
+  // updateContact(id) {
+  //   const editRef = firebase.database().ref(`contacts/${id}`);
+  //   editRef.push(this.state);
+  // }
 
   render() {
     return (
@@ -58,7 +54,7 @@ export default class AddContact extends Component {
             style={styles.inputFields}
             placeholder='First Name'
             onChangeText={firstName => this.setState({firstName})}
-            value={this.state.firstName}
+            value={this.state.firstName || this.props.firstName}
             onSubmitEditing={e => this.refs.lastNameInput.focus()}
           />
         </View>
@@ -68,7 +64,7 @@ export default class AddContact extends Component {
             style={styles.inputFields}
             placeholder='Last Name'
             onChangeText={lastName => this.setState({lastName})}
-            value={this.state.lastName}
+            value={this.state.lastName || this.props.lastName}
           />
         </View>
         <View>

--- a/app/screens/IndividualContact.js
+++ b/app/screens/IndividualContact.js
@@ -18,18 +18,19 @@ export default class IndividualContact extends Component {
     this.createNotes = this.createNotes.bind(this);
   }
 
-  // componentDidMount() {
-  //   contactsRef.on('child_added', (snapshot) => {
-  //     let notes = snapshot.val();
-  //     if(!notes) { return this.setState({ notes: [], dataSource: this.state.dataSource.cloneWithRows({}) }); }
-  //     notes = split(notes).map(note => (console.log(note.value.notes)));
-  //     this.setState({
-  //       dataSource: this.state.dataSource.cloneWithRows(notes),
-  //       notes: notes
-  //     });
-  //   });
-  // }
-  //
+  componentDidMount() {
+    contactsRef.on('child_added', (snapshot) => {
+      let notes = snapshot.val();
+      if(!notes) { return this.setState({ notes: [], dataSource: this.state.dataSource.cloneWithRows({}) }); }
+      notes = split(notes).map(note => Object.assign({ id: note.key }, console.log(note.value.notes)));
+      this.setState({
+        dataSource: this.state.dataSource.cloneWithRows(notes),
+        notes: notes
+      });
+      console.log(notes)
+    });
+  }
+
   createNotes(id) {
     const notesRef = firebase.database().ref(`contacts/${id}`);
     notesRef.push({notes: this.state.notesInput});
@@ -37,8 +38,8 @@ export default class IndividualContact extends Component {
 
   render() {
     return (
-      <View style={styles.individualContact}>
-      {/* <View> */}
+      // <View style={styles.individualContact}>
+      <View>
         <View>
           { !this.props.avatar ? <Image style={styles.individualAvatar} source={require('../img/individual-avatar.png')} /> :
             <Image style={styles.individualAvatar} source={{uri: this.props.avatar.uri}} />
@@ -54,15 +55,15 @@ export default class IndividualContact extends Component {
             value={this.state.notesInput}
           />
         </View>
-        {/* <ListView
+        <ListView
           style={{backgroundColor: 'red'}}
           enableEmptySections
           dataSource={this.state.dataSource}
-          renderRow={(notes) => <Text>{notes}</Text>}
-        /> */}
+          renderRow={(notes) => <Text>{notes.notesInput}</Text>}
+        />
         <Button onPress={e => this.createNotes(this.props.id)} title="Save" />
         <View style={styles.row}>
-          <Button onPress={() => Actions.addContacts({firstName: this.props.firstName, lastName: this.props.lastName, birthdayDate: this.props.birthdayDate, avatar: this.props.avatar})} title="Edit" />
+          <Button onPress={() => Actions.addContacts({firstName: this.props.firstName, lastName: this.props.lastName, birthdayDate: this.props.birthdayDate, avatar: this.props.avatar, id: this.props.id})} title="Edit" />
           <Button onPress={e => this.props.onPress(this.props.id)} title="Delete" />
         </View>
       </View>

--- a/app/screens/IndividualContact.js
+++ b/app/screens/IndividualContact.js
@@ -15,31 +15,30 @@ export default class IndividualContact extends Component {
       notesInput: '',
       notes: []
     };
-    this.createNotes = this.createNotes.bind(this);
+    // this.createNotes = this.createNotes.bind(this);
   }
 
-  componentDidMount() {
-    contactsRef.on('child_added', (snapshot) => {
-      let notes = snapshot.val();
-      if(!notes) { return this.setState({ notes: [], dataSource: this.state.dataSource.cloneWithRows({}) }); }
-      notes = split(notes).map(note => Object.assign({ id: note.key }, console.log(note.value.notes)));
-      this.setState({
-        dataSource: this.state.dataSource.cloneWithRows(notes),
-        notes: notes
-      });
-      console.log(notes)
-    });
-  }
+  // componentDidMount() {
+  //   contactsRef.on('child_added', (snapshot) => {
+  //     let notes = snapshot.val();
+  //     if(!notes) { return this.setState({ notes: [], dataSource: this.state.dataSource.cloneWithRows({}) }); }
+  //     notes = split(notes).map(note => Object.assign({ id: note.key }, note.value));
+  //     this.setState({
+  //       dataSource: this.state.dataSource.cloneWithRows(notes),
+  //       notes: notes
+  //     });
+  //   });
+  // }
 
-  createNotes(id) {
-    const notesRef = firebase.database().ref(`contacts/${id}`);
-    notesRef.push({notes: this.state.notesInput});
-  }
+  // createNotes(id) {
+  //   const notesRef = firebase.database().ref(`contacts/${id}`);
+  //   notesRef.push({notes: this.state.notesInput});
+  // }
 
   render() {
     return (
-      // <View style={styles.individualContact}>
-      <View>
+      <View style={styles.individualContact}>
+      {/* <View> */}
         <View>
           { !this.props.avatar ? <Image style={styles.individualAvatar} source={require('../img/individual-avatar.png')} /> :
             <Image style={styles.individualAvatar} source={{uri: this.props.avatar.uri}} />
@@ -55,13 +54,13 @@ export default class IndividualContact extends Component {
             value={this.state.notesInput}
           />
         </View>
-        <ListView
+        {/* <ListView
           style={{backgroundColor: 'red'}}
           enableEmptySections
           dataSource={this.state.dataSource}
           renderRow={(notes) => <Text>{notes.notesInput}</Text>}
-        />
-        <Button onPress={e => this.createNotes(this.props.id)} title="Save" />
+        /> */}
+        {/* <Button onPress={e => this.createNotes(this.props.id)} title="Save" /> */}
         <View style={styles.row}>
           <Button onPress={() => Actions.addContacts({firstName: this.props.firstName, lastName: this.props.lastName, birthdayDate: this.props.birthdayDate, avatar: this.props.avatar, id: this.props.id})} title="Edit" />
           <Button onPress={e => this.props.onPress(this.props.id)} title="Delete" />


### PR DESCRIPTION
@stevekinney

I've been working on trying to render notes and editing contacts in my individualContact component all weekend. I haven't been successful because I think I haven't been passing my props correctly through the routing. I've been trying several different ways, but the current code is what is somewhat working.

In the video below when you click on a contact in the contact list and then the edit button the field inputs are correct in the addContact component. However, when you go back to the contact list and click on another contact those same props are rendering in the field inputs. They are only cleared when you click on the cancel button. I was trying to do `componentWillUnmount`, but wasn't successful and then I tried `type=reset` in my router since I'm using react-native-router-flux. Here's some docs I was referring to: [Refresh Scene](https://github.com/aksonov/react-native-router-flux/blob/master/docs/OTHER_INFO.md#switch-new-feature), [type=reset](https://github.com/aksonov/react-native-router-flux/issues/467)

![Video](http://g.recordit.co/vp9zcLMOxg.gif)

As for rendering my notes, I'm setting the state of the notes within the individualContact component and mounting the notes within that component. 
Below is my Firebase nesting:
<img width="358" alt="firebase-tree" src="https://cloud.githubusercontent.com/assets/17103622/20047247/8fa9cbf4-a46f-11e6-84d0-c328fc05ac58.png">

I'm able to see the individual notes in my console by `notes = split(notes).map(note => Object.assign({ id: note.key }, console.log(note.value.notes)));` but for some reason the notes is still equal to the other objects already in Firebase which is the firstName, lastName, and birthdayDate. Also nothing is rendering...I can only see the objects in my console. I don't think I'm navigating to the correct children in the Firebase tree. 

Your help would be greatly appreciated and please let me know if my approach to these problems is incorrect, thanks! 